### PR TITLE
JPEG format for consistent orientation and lower size images

### DIFF
--- a/app_005/SecondViewController.swift
+++ b/app_005/SecondViewController.swift
@@ -24,8 +24,8 @@ UINavigationControllerDelegate {
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         if let pickedImage = info[UIImagePickerControllerOriginalImage] as? UIImage {
-            let imageData = UIImagePNGRepresentation(pickedImage)
-            let imageFile = PFFile(name:"imageFile.png", data:imageData!)
+            let imageData = UIImageJPEGRepresentation(pickedImage, 0) // "0" indicates lowest size/quality
+            let imageFile = PFFile(name:"imageFile.jpeg", data:imageData!)
             let GeoPhoto = PFObject(className:"GeoPhoto")
             GeoPhoto["imageFile"] = imageFile
             GeoPhoto.saveInBackground()


### PR DESCRIPTION
Image size option for jpeg is "0" which is lowest out of 0, 0.25, 0.5, 0.75, 1.0, but still looks great. You can check this on the parse dashboard. 